### PR TITLE
fix memory allocation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ tar -zxvf longcallD-v0.0.10.tar.gz
 cd longcallD-v0.0.10; make
 ```
 
+### Build from repository
+To compile longcallD from the repository, run:
+```
+git clone https://github.com/yangao07/longcallD.git
+cd longcallD
+git submodule update --init --recursive
+make
+```
+
 ## Usage
 LongcallD requires a **reference genome (FASTA)** and a **long-read BAM/CRAM** file as inputs. It outputs **phased variant calls in VCF format**.
 ### Variant calling with PacBio HiFi/Nanopore long reads

--- a/src/call_var_main.c
+++ b/src/call_var_main.c
@@ -545,7 +545,7 @@ static int collect_regions_from_bed_file(call_var_opt_t *opt, call_var_pl_t *pl)
         }
         if (beg > end || beg <= 0 || end <= 0) continue;
         if (n_regions == m_regions) {
-            n_regions *= 2;
+            m_regions *= 2; // should be m, not n_regions
             regions = (char**)realloc(regions, m_regions * sizeof(char*));
             for (int i = n_regions; i < m_regions; ++i) regions[i] = (char*)malloc(1024);
         }


### PR DESCRIPTION
When a `--region-file` has >1024 lines, a segmentation fault was thrown. The fix was a single character change (n -> m).

Also, I added a note in README for building the tool from the repository. I always forget to do the submodule pull, so maybe other users will also need a reminder.


Have a great day!